### PR TITLE
chore: add cloudposse/utils provider for remote-state v2.0.0 compat

### DIFF
--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   sources:
     - component: "account-map"
-      source: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
-      version: 1.520.0
+      source: github.com/cloudposse-terraform-components/aws-account-map.git//src?ref={{.Version}}
+      version: v1.537.2
       targets:
         - "components/terraform/account-map"
       included_paths:


### PR DESCRIPTION
## Summary
- Add `cloudposse/utils` provider constraint `>= 2.0.0, < 3.0.0`
- Update vendored account-map to standalone repo at v1.537.2
- Required for compatibility when vendored by components using remote-state v2.0.0

## Test plan
- [ ] CI lint passes
- [ ] Terratest passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vendor configuration for the account-map component with new repository reference and version `v1.537.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->